### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # https-github.com-gau
+getallurls (gau) fetches known URLs from AlienVault's Open Threat Exchange, the Wayback Machine, and Common Crawl for any given domain. Inspired by Tomnomnom's waybackurls.
+
+Resources
+Usage
+Installation
+ohmyzsh note
+Usage:
+Examples:
+
+$ printf example.com | gau
+$ cat domains.txt | gau -t 5
+$ gau example.com
+$ gau -o example-urls.txt example.com
+$ gau -b png,jpg,gif example.com
+To display the help for the tool use the -h flag:
+
+$ gau -h
+Flag	Description	Example
+-providers	providers to fetch urls from (by default, all are used)	gau -providers wayback,otx,commoncrawl example.com
+-b	extensions to skip	gau -b jpg,png,gif example.com
+-retries	amount of retries for http client	gau -retries 7 example.com
+-subs	include subdomains of target domain	gau -subs example.com
+-t	number of threads to use	gau -t 5
+-p	http proxy to use	gau -p http://localhost:8080 example.com
+-v	enable verbose mode (show errors)	gau -v
+-o	filename to write results to	gau -o urls.txt example.com
+-json	write output as json	gau -json example.com
+-version	show gau version	gau -version
+Installation:
+From source:
+$ GO111MODULE=on go get -u -v github.com/lc/gau
+From binary:
+You can download the pre-built binaries from the releases page and then move them into your $PATH.
+
+From Docker:
+You can build a docker image with the following command
+
+docker build -t gau .
+and then run it
+
+docker run gau example.com
+Bear in mind that piping command (echo "example.com" | gau) will not work with the docker container
+
+$ tar xvf gau_1.1.0_linux_amd64.tar.gz
+$ mv gau /usr/bin/gau
+ohmyzsh note:
+ohmyzsh's git plugin has an alias which maps gau to the git add --update command. This is problematic, causing a binary conflict between this tool "gau" and the zsh plugin alias "gau" (git add --update). There is currently a few workarounds which can be found in this Github issue


### PR DESCRIPTION
getallurls (gau) fetches known URLs from AlienVault's Open Threat Exchange, the Wayback Machine, and Common Crawl for any given domain. Inspired by Tomnomnom's waybackurls.

Resources
Usage
Installation
ohmyzsh note
Usage:
Examples:

$ printf example.com | gau
$ cat domains.txt | gau -t 5
$ gau example.com
$ gau -o example-urls.txt example.com
$ gau -b png,jpg,gif example.com
To display the help for the tool use the -h flag:

$ gau -h
Flag	Description	Example
-providers	providers to fetch urls from (by default, all are used)	gau -providers wayback,otx,commoncrawl example.com
-b	extensions to skip	gau -b jpg,png,gif example.com
-retries	amount of retries for http client	gau -retries 7 example.com
-subs	include subdomains of target domain	gau -subs example.com
-t	number of threads to use	gau -t 5
-p	http proxy to use	gau -p http://localhost:8080 example.com
-v	enable verbose mode (show errors)	gau -v
-o	filename to write results to	gau -o urls.txt example.com
-json	write output as json	gau -json example.com
-version	show gau version	gau -version
Installation:
From source:
$ GO111MODULE=on go get -u -v github.com/lc/gau
From binary:
You can download the pre-built binaries from the releases page and then move them into your $PATH.

From Docker:
You can build a docker image with the following command

docker build -t gau .
and then run it

docker run gau example.com
Bear in mind that piping command (echo "example.com" | gau) will not work with the docker container

$ tar xvf gau_1.1.0_linux_amd64.tar.gz
$ mv gau /usr/bin/gau
ohmyzsh note:
ohmyzsh's git plugin has an alias which maps gau to the git add --update command. This is problematic, causing a binary conflict between this tool "gau" and the zsh plugin alias "gau" (git add --update). There is currently a few workarounds which can be found in this Github issue